### PR TITLE
Accident model health states

### DIFF
--- a/extensions/health/src/main/java/de/tum/bgu/msm/health/disease/Diseases.java
+++ b/extensions/health/src/main/java/de/tum/bgu/msm/health/disease/Diseases.java
@@ -30,7 +30,7 @@ public enum Diseases {
     severely_injured_car,
     severely_injured_walk,
     severely_injured_bike,
-    killed_car,
-    killed_walk,
-    killed_bike
+    dead_car,
+    dead_walk,
+    dead_bike
 }

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DeathStrategyMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DeathStrategyMCR.java
@@ -71,10 +71,10 @@ public class DeathStrategyMCR implements DeathStrategy {
                 Diseases.endometrial_cancer,
                 Diseases.colon_cancer,
                 Diseases.bladder_cancer,
-                Diseases.esophageal_cancer,
-                Diseases.gastric_cardia_cancer,
+                //Diseases.esophageal_cancer,
+                //Diseases.gastric_cardia_cancer,
                 Diseases.head_neck_cancer,
-                Diseases.liver_cancer,
+                //Diseases.liver_cancer,
                 Diseases.lung_cancer,
                 Diseases.rectum_cancer
         );
@@ -114,6 +114,7 @@ public class DeathStrategyMCR implements DeathStrategy {
         }
 
 
+
         // todo: what happens with people < 18
         if (!Collections.disjoint(currentDiseases, injuries)) {
             if (person.getGender().equals(Gender.MALE)) {
@@ -122,6 +123,7 @@ public class DeathStrategyMCR implements DeathStrategy {
                 alpha *= 1.74;
             }
         }
+
         return alpha;
     }
 }

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DeathStrategyMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DeathStrategyMCR.java
@@ -38,9 +38,9 @@ public class DeathStrategyMCR implements DeathStrategy {
 
         // check killed by injury
         Set<Diseases> killedInAccident = Set.of(
-                Diseases.killed_car,
-                Diseases.killed_bike,
-                Diseases.killed_walk
+                Diseases.dead_car,
+                Diseases.dead_bike,
+                Diseases.dead_walk
         );
 
         if (!Collections.disjoint(((PersonHealth) person).getCurrentDisease(), killedInAccident)) {

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
@@ -252,7 +252,9 @@ public class DiseaseModelMCR extends AbstractModel implements ModelUpdateListene
                 }
             } else {
                 List<String> fullDisease = new ArrayList<>();
-                if (personHealth.getHealthDiseaseTracker().get(year - 1) != null) {
+                // DO NOT add previous states when a person has died in the injury model. These states are exclusive.
+                if (personHealth.getHealthDiseaseTracker().get(year - 1) != null &&
+                        !(newDisease.equals(Diseases.dead_bike) || newDisease.equals(Diseases.dead_walk) || newDisease.equals(Diseases.dead_car))) {
                     fullDisease.addAll(personHealth.getHealthDiseaseTracker().get(year - 1)); // get old diseases
                 }
                 fullDisease.addAll(newDisease); // add new diseases

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
@@ -198,7 +198,8 @@ public class DiseaseModelMCR extends AbstractModel implements ModelUpdateListene
     private void initializeHealthDiseaseStates() {
         Map<Integer, List<Diseases>> prevData = ((HealthDataContainerImpl) dataContainer).getPrevalenceData();
         for (Person person : dataContainer.getHouseholdDataManager().getPersons()) {
-            if (prevData.keySet().contains(person.getId()) && (!prevData.get(person.getId()).contains(null))) {
+            if (prevData.keySet().contains(person.getId()) && (!prevData.get(person.getId()).contains(null)) &&
+                    person.getAge() > 17) {
                 List<String> diseaseList = prevData.get(person.getId())  // Returns List<Diseases>
                         .stream()                                      // Convert List to Stream
                         .map(Enum::name)                               // Map each enum to its name
@@ -210,6 +211,7 @@ public class DiseaseModelMCR extends AbstractModel implements ModelUpdateListene
             }
         }
     }
+
 
 
     public void updateHealthDiseaseStates(int year) {

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
@@ -64,7 +64,7 @@ public class DiseaseModelMCR extends AbstractModel implements ModelUpdateListene
                 EnumMap<Diseases, Float> rr = new EnumMap<>(Diseases.class);
 
                 for (Diseases diseases : ((DataContainerHealth) dataContainer).getDoseResponseData().get(exposures).keySet()) {
-                    if (diseases.equals(Diseases.killed_bike) || diseases.equals(Diseases.killed_walk) || diseases.equals(Diseases.killed_car) ||
+                    if (diseases.equals(Diseases.dead_bike) || diseases.equals(Diseases.dead_walk) || diseases.equals(Diseases.dead_car) ||
                             diseases.equals(Diseases.severely_injured_car) || diseases.equals(Diseases.severely_injured_walk) || diseases.equals(Diseases.severely_injured_bike)) {
                         continue;
                     }

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/DiseaseModelMCR.java
@@ -196,30 +196,21 @@ public class DiseaseModelMCR extends AbstractModel implements ModelUpdateListene
     }
     private void initializeHealthDiseaseStates() {
         Map<Integer, List<Diseases>> prevData = ((HealthDataContainerImpl) dataContainer).getPrevalenceData();
-
-        // Flatten the List<Diseases> values and collect only non-null entries
-        List<List<Diseases>> availableDiseaseLists = prevData.values().stream()
-                .filter(list -> list != null && !list.contains(null))
-                .collect(Collectors.toCollection(ArrayList::new));
-
-        // Shuffle to ensure randomness
-        Collections.shuffle(availableDiseaseLists, new Random());
-
-        Iterator<List<Diseases>> diseaseIterator = availableDiseaseLists.iterator();
-
         for (Person person : dataContainer.getHouseholdDataManager().getPersons()) {
-            if (person.getAge() > 17 && diseaseIterator.hasNext()) {
-                List<Diseases> diseaseEnums = diseaseIterator.next(); // Get next unique disease list
-                List<String> diseaseList = diseaseEnums.stream()
-                        .map(Enum::name)
-                        .collect(Collectors.toList());
+            if (prevData.keySet().contains(person.getId()) && (!prevData.get(person.getId()).contains(null)) &&
+                    person.getAge() > 17) {
+                List<String> diseaseList = prevData.get(person.getId())  // Returns List<Diseases>
+                        .stream()                                      // Convert List to Stream
+                        .map(Enum::name)                               // Map each enum to its name
+                        .collect(Collectors.toList());                 // Collect into List<String>
                 ((PersonHealth) person).getHealthDiseaseTracker().put(Properties.get().main.startYear - 1, diseaseList);
             } else {
-                // Either person is 17 or younger OR no more unique disease data available
+                //start year-1 as initial state
                 ((PersonHealth) person).getHealthDiseaseTracker().put(Properties.get().main.startYear - 1, Arrays.asList("healthy"));
             }
         }
     }
+
 
     public void updateHealthDiseaseStates(int year) {
         for (Person person : dataContainer.getHouseholdDataManager().getPersons()) {

--- a/useCases/manchester/src/main/java/de/tum/bgu/msm/health/InjurySampler.java
+++ b/useCases/manchester/src/main/java/de/tum/bgu/msm/health/InjurySampler.java
@@ -230,11 +230,11 @@ public class InjurySampler {
     private Diseases getFatalInjuryDisease(String mode) {
         switch (mode) {
             case "Car":
-                return Diseases.killed_car;
+                return Diseases.dead_car;
             case "Bike":
-                return Diseases.killed_bike;
+                return Diseases.dead_bike;
             case "Walk":
-                return Diseases.killed_walk;
+                return Diseases.dead_walk;
             default:
                 throw new IllegalArgumentException("Unknown mode: " + mode);
         }


### PR DESCRIPTION
Did three things:
- rename `killed` to `dead` - for consistency
- made sure that `dead` by mode state is exclusive, so `copd|dead_car` should be `dead_car`
- assigned prevalanece to only those that are 18 or above. Rest of them start as `healthy`


@ismailsaadi , would you please review the changes and merge them to the accidentModel branch? We need to merge accidentModel to accidentModel_osm too.  I am going to create another pull-request for it. Thanks!